### PR TITLE
Refactor deploy workflow to remove duplicate overwrite property

### DIFF
--- a/.github/workflows/deploy-remote.yml
+++ b/.github/workflows/deploy-remote.yml
@@ -56,9 +56,6 @@ jobs:
           overwrite: true
 
       # 4) Deploy via SSH
-          overwrite: true
-
-      # 4) Deploy via SSH
       - name: SSH into VDS and deploy
         uses: appleboy/ssh-action@v1.0.3
         with:


### PR DESCRIPTION
Eliminate redundant overwrite property in the deploy workflow for cleaner configuration.