### PR TITLE
Refactor deploy workflow source file specification

### DIFF
--- a/.github/workflows/deploy-remote.yml
+++ b/.github/workflows/deploy-remote.yml
@@ -49,9 +49,7 @@ jobs:
           username: ${{ secrets.VDS_USER }}
           key: ${{ secrets.VDS_SSH_KEY }}
           passphrase: ${{ secrets.VDS_SSH_PASSPHRASE }}
-          source: |
-            ./docker-compose.prod.yml
-            ./Caddyfile
+          source: "docker-compose.prod.yml,Caddyfile"
           target: ${{ secrets.VDS_WORKDIR }}
           overwrite: true
 


### PR DESCRIPTION
Simplify the specification of source files in the deploy workflow by using a comma-separated string instead of multiple lines.