### PR TITLE
Allow pushes from master alongside codex branches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+if [ -z "$branch" ]; then
+  echo "Unable to determine the current branch. Push aborted." >&2
+  exit 1
+fi
+
+case "$branch" in
+  codex/*|master)
+    exit 0
+    ;;
+  *)
+    echo "Pushes are restricted to branches named codex/* or master (current: $branch)." >&2
+    echo "Create or switch to a codex/* branch or master before pushing." >&2
+    exit 1
+    ;;
+esac

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 This is a starter skeleton for a learning project: Go backend + Vue 3 frontend,
 containerised and set up for local dev with Vite proxying `/api` to the Go server.
+
+## Codex branch push guard
+
+To force Codex pushes to use the `codex/*` naming convention, enable the provided Git hook:
+
+```
+git config core.hooksPath .githooks
+```
+
+With the hook enabled, `git push` will fail unless you are on a branch named `codex/<something>` or on `master`.


### PR DESCRIPTION
## Summary
- allow the shared pre-push hook to accept pushes from master as well as codex/* branches
- update documentation to reflect the master exception for pushes

## Testing
- not run (documentation and git hook changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418713a1d883239ef477311459f47b)