### PR TITLE
Extract router builder

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	appdb "TrackAndFeel/backend/internal/db"
-	"TrackAndFeel/backend/internal/handlers"
 	"TrackAndFeel/backend/internal/migrate"
 )
 
@@ -30,19 +29,8 @@ func main() {
 		log.Fatalf("migrations: %v", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("ok"))
-	})
-	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte(Commit))
-	})
-	mux.Handle("/api/upload", handlers.Upload(pool))
-	mux.Handle("/api/activities", handlers.ListActivities(pool))
-	mux.Handle("/api/activities/", handlers.GetActivityTrack(pool)) // expects /api/activities/{id}/track
-
 	port := getenv("PORT", "8080")
-	srv := &http.Server{Addr: ":" + port, Handler: mux}
+	srv := &http.Server{Addr: ":" + port, Handler: buildRouter(pool)}
 
 	// start
 	go func() {

--- a/backend/cmd/server/router.go
+++ b/backend/cmd/server/router.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+
+	"TrackAndFeel/backend/internal/handlers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func buildRouter(pool *pgxpool.Pool) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(Commit))
+	})
+	mux.Handle("/api/upload", handlers.Upload(pool))
+	mux.Handle("/api/activities", handlers.ListActivities(pool))
+	mux.Handle("/api/activities/", handlers.GetActivityTrack(pool)) // expects /api/activities/{id}/track
+
+	return mux
+}


### PR DESCRIPTION
## Summary
- introduce a buildRouter helper to centralize server route registration
- update main server startup to use the shared router builder

## Testing
- not run (go test ./... hung in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69496f4bbff0832383860067a286f7c2)