### PR TITLE
Add disposable container for backend tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ down:
 dev: up logs
 
 test:
-	cd backend && go test ./...
+	docker compose -f docker-compose.yml -f docker-compose.test.yml run --rm backend-test
 	# add frontend tests later
 
 lint:

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ git config core.hooksPath .githooks
 ```
 
 With the hook enabled, `git push` will fail unless you are on a branch named `codex/<something>` or on `master`.
+
+## Tests
+
+Run backend tests in a disposable container so nothing lingers after the run:
+
+```
+docker compose -f docker-compose.yml -f docker-compose.test.yml run --rm backend-test
+```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,8 @@
+services:
+  backend-test:
+    image: golang:1.23
+    container_name: trackandfeel-backend-test
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: sh -c "go mod download && go test ./..."


### PR DESCRIPTION
## Summary
- add a docker-compose.test.yml service that runs backend Go tests in a disposable container
- update the Makefile test target to invoke the containerized test run
- document how to run the disposable test container in the README

## Testing
- go test ./...
- go test -run TestParseTime -v ./internal/gpx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a4a8fff883239b2ef6818ecf6644)