### PR TITLE
Add activity map coloring modes for laps, distance, speed, and heart rate

### DIFF
--- a/frontend/src/components/TrackMap.vue
+++ b/frontend/src/components/TrackMap.vue
@@ -5,9 +5,12 @@ import 'leaflet/dist/leaflet.css'
 
 const props = defineProps({
   coords: { type: Array, required: true }, // [[lon,lat], ...] from /track geojson
+  segments: { type: Array, default: () => [] }, // [{ coords, color?, label? }]
+  legend: { type: Array, default: () => [] }, // [{ color, label }]
 })
 
 let map, layer
+let segmentLayers = []
 const mapEl = ref(null)
 
 onMounted(() => {
@@ -20,24 +23,51 @@ onMounted(() => {
   draw()
 })
 
-watch(() => props.coords, draw, { deep: true })
+watch(
+  () => [props.coords, props.segments],
+  () => draw(),
+  { deep: true }
+)
 
 function draw() {
   if (!map || !props.coords?.length) return
   if (layer) layer.remove()
+  if (segmentLayers.length) {
+    segmentLayers.forEach((l) => l.remove())
+    segmentLayers = []
+  }
 
-  // convert [lon,lat] -> [lat,lon] for Leaflet
-  const latlngs = props.coords.map(([lon, lat]) => [lat, lon])
-  layer = L.polyline(latlngs, { weight: 4 }).addTo(map)
-  map.fitBounds(layer.getBounds(), { padding: [20, 20] })
+  if (props.segments?.length) {
+    const bounds = []
+    for (const seg of props.segments) {
+      const latlngs = seg.coords.map(([lon, lat]) => [lat, lon])
+      const l = L.polyline(latlngs, { weight: 5, color: seg.color || '#3366cc' }).addTo(map)
+      segmentLayers.push(l)
+      bounds.push(...latlngs)
+    }
+    if (bounds.length) map.fitBounds(bounds, { padding: [20, 20] })
+  } else {
+    // convert [lon,lat] -> [lat,lon] for Leaflet
+    const latlngs = props.coords.map(([lon, lat]) => [lat, lon])
+    layer = L.polyline(latlngs, { weight: 4 }).addTo(map)
+    map.fitBounds(layer.getBounds(), { padding: [20, 20] })
+  }
 }
 
 onBeforeUnmount(() => map && map.remove())
 </script>
 
 <template>
-  <div
-    ref="mapEl"
-    style="height: 360px; width: 100%; border: 1px solid #eee; border-radius: 8px"
-  ></div>
+  <div>
+    <div
+      ref="mapEl"
+      style="height: 360px; width: 100%; border: 1px solid #eee; border-radius: 8px"
+    ></div>
+    <div v-if="legend?.length" style="display: flex; gap: 12px; flex-wrap: wrap; margin-top: 8px">
+      <div v-for="item in legend" :key="item.label" style="display: flex; align-items: center; gap: 6px">
+        <span :style="{ width: '16px', height: '4px', backgroundColor: item.color, display: 'inline-block' }"></span>
+        <span style="font-size: 12px">{{ item.label }}</span>
+      </div>
+    </div>
+  </div>
 </template>

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -12,6 +12,7 @@ const store = useActivitiesStore()
 const detail = ref(null)
 const loading = computed(() => store.loading)
 const error = computed(() => store.error)
+const coloring = ref('kilometers') // laps | kilometers | speed | hr
 
 onMounted(async () => {
   try {
@@ -47,6 +48,153 @@ const speedSeries = computed(() => {
       return src
   }
 })
+
+// Helpers for map coloring
+const palette = ['#2c7bb6', '#00a6ca', '#00ccbc', '#90eb9d', '#ffff8c', '#f9d057', '#f29e2e', '#e76818', '#d7191c', '#9e0142']
+
+function haversineMeters(lat1, lon1, lat2, lon2) {
+  const toRad = (d) => (d * Math.PI) / 180
+  const R = 6371000
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
+
+const trackPoints = computed(() => {
+  if (!detail.value) return []
+  const coords = detail.value.geojson.geometry.coordinates
+  const times = detail.value.series.time_iso
+  const hr = detail.value.series.hr
+  const speed = detail.value.series.speed_mps
+
+  let total = 0
+  const pts = []
+  for (let i = 0; i < coords.length; i++) {
+    const [lon, lat] = coords[i]
+    if (i > 0) {
+      const [prevLon, prevLat] = coords[i - 1]
+      total += haversineMeters(prevLat, prevLon, lat, lon)
+    }
+    pts.push({ lon, lat, t: times?.[i], hr: hr?.[i], speed: speed?.[i], dist: total })
+  }
+  return pts
+})
+
+function quantile(sortedVals, q) {
+  if (!sortedVals.length) return 0
+  const idx = Math.max(0, Math.min(sortedVals.length - 1, Math.floor((sortedVals.length - 1) * q)))
+  return sortedVals[idx]
+}
+
+function buildBucketSegments(points, valueFn, labels) {
+  const values = points.map(valueFn).filter((v) => Number.isFinite(v))
+  if (!values.length) return { segments: [], legend: [] }
+
+  values.sort((a, b) => a - b)
+  const thresholds = [quantile(values, 0.25), quantile(values, 0.5), quantile(values, 0.75)]
+
+  const legend = []
+  const segments = []
+
+  let currentBucket = null
+  let currentCoords = []
+  for (let i = 0; i < points.length; i++) {
+    const v = valueFn(points[i])
+    let bucket = -1
+    if (Number.isFinite(v)) {
+      if (v <= thresholds[0]) bucket = 0
+      else if (v <= thresholds[1]) bucket = 1
+      else if (v <= thresholds[2]) bucket = 2
+      else bucket = 3
+    }
+
+    const coord = [points[i].lon, points[i].lat]
+    if (bucket !== currentBucket) {
+      if (currentCoords.length > 1 && currentBucket != null && currentBucket >= 0) {
+        const color = palette[currentBucket]
+        segments.push({ coords: currentCoords, color, label: labels[currentBucket] })
+        if (!legend.some((l) => l.label === labels[currentBucket])) legend.push({ color, label: labels[currentBucket] })
+      }
+      currentCoords = bucket >= 0 ? [coord] : []
+      currentBucket = bucket
+    } else if (bucket >= 0) {
+      currentCoords.push(coord)
+    }
+  }
+  if (currentCoords.length > 1 && currentBucket != null && currentBucket >= 0) {
+    const color = palette[currentBucket]
+    segments.push({ coords: currentCoords, color, label: labels[currentBucket] })
+    if (!legend.some((l) => l.label === labels[currentBucket])) legend.push({ color, label: labels[currentBucket] })
+  }
+  return { segments, legend }
+}
+
+function buildBoundarySegments(points, boundaries, labelForIdx) {
+  const segments = []
+  const legend = []
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const start = boundaries[i]
+    const end = boundaries[i + 1]
+    if (end <= start) continue
+    const coords = points.slice(start, end + 1).map((p) => [p.lon, p.lat])
+    if (coords.length < 2) continue
+    const color = palette[i % palette.length]
+    const label = labelForIdx(i)
+    segments.push({ coords, color, label })
+    legend.push({ color, label })
+  }
+  return { segments, legend }
+}
+
+const coloredTrack = computed(() => {
+  const pts = trackPoints.value
+  if (!pts.length) return { segments: [], legend: [] }
+
+  if (coloring.value === 'kilometers') {
+    const bounds = [0]
+    let next = 1000
+    for (let i = 1; i < pts.length; i++) {
+      if (pts[i].dist >= next) {
+        bounds.push(i)
+        next += 1000
+      }
+    }
+    bounds.push(pts.length - 1)
+    return buildBoundarySegments(pts, bounds, (i) => `Km ${i + 1}`)
+  }
+
+  if (coloring.value === 'laps') {
+    const bounds = [0]
+    const lapMinDist = 150 // meters to avoid noise
+    const startLat = pts[0].lat
+    const startLon = pts[0].lon
+    for (let i = 1; i < pts.length - 1; i++) {
+      const sinceLap = pts[i].dist - pts[bounds[bounds.length - 1]].dist
+      const distFromStart = haversineMeters(startLat, startLon, pts[i].lat, pts[i].lon)
+      if (sinceLap >= lapMinDist && distFromStart < 25) {
+        bounds.push(i)
+      }
+    }
+    if (bounds[bounds.length - 1] !== pts.length - 1) bounds.push(pts.length - 1)
+    return buildBoundarySegments(pts, bounds, (i) => `Lap ${i + 1}`)
+  }
+
+  if (coloring.value === 'speed') {
+    const labels = ['Very slow', 'Easy', 'Moderate', 'Fastest']
+    return buildBucketSegments(pts, (p) => (p.speed == null ? NaN : p.speed * 3.6), labels)
+  }
+
+  if (coloring.value === 'hr') {
+    const labels = ['Low HR', 'Aerobic', 'Tempo', 'Max effort']
+    return buildBucketSegments(pts, (p) => (p.hr == null ? NaN : p.hr), labels)
+  }
+
+  return { segments: [], legend: [] }
+})
 </script>
 
 <template>
@@ -68,7 +216,19 @@ const speedSeries = computed(() => {
       <button :disabled="store.unit === 'pace'" @click="store.setUnit('pace')">min/km</button>
     </div>
 
-    <TrackMap :coords="detail.geojson.geometry.coordinates" />
+    <div style="margin: 12px 0; display: flex; gap: 8px; align-items: center; flex-wrap: wrap">
+      <span>Track coloring:</span>
+      <button :disabled="coloring === 'kilometers'" @click="coloring = 'kilometers'">Kilometres</button>
+      <button :disabled="coloring === 'laps'" @click="coloring = 'laps'">Laps</button>
+      <button :disabled="coloring === 'speed'" @click="coloring = 'speed'">Speed</button>
+      <button :disabled="coloring === 'hr'" @click="coloring = 'hr'">Heart rate</button>
+    </div>
+
+    <TrackMap
+      :coords="detail.geojson.geometry.coordinates"
+      :segments="coloredTrack.segments"
+      :legend="coloredTrack.legend"
+    />
 
     <section style="margin-top: 16px; display: grid; gap: 16px">
       <TimeSeriesChart


### PR DESCRIPTION
## Summary
- add track coloring controls to the activity view for kilometres, laps, speed buckets, and heart rate buckets
- compute derived track distance, lap detection, and bucketization to feed segmented map overlays with legends
- update the map component to render coloured segments with an inline legend alongside the existing polyline view

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a815a81888323b41120061573450a)