### PR TITLE
Compute pace on backend

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"TrackAndFeel/backend/internal/gpx"
+	"TrackAndFeel/backend/internal/series"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -206,6 +207,7 @@ func GetActivityTrack(pool *pgxpool.Pool) http.Handler {
 		ele := make([]*float64, 0, len(points))
 		hr := make([]*int, 0, len(points))
 		spd := make([]*float64, 0, len(points))
+		pace := make([]*float64, 0, len(points))
 
 		for _, p := range points {
 			coords = append(coords, [2]float64{p.Lon, p.Lat})
@@ -214,6 +216,8 @@ func GetActivityTrack(pool *pgxpool.Pool) http.Handler {
 			hr = append(hr, p.HR)
 			spd = append(spd, p.Spd)
 		}
+
+		pace = series.SpeedToPaceMinPerKm(spd)
 
 		resp := map[string]any{
 			"id": actID.String(),
@@ -234,10 +238,11 @@ func GetActivityTrack(pool *pgxpool.Pool) http.Handler {
 				"properties": map[string]any{},
 			},
 			"series": map[string]any{
-				"time_iso":  timeISO,
-				"elevation": ele,
-				"hr":        hr,
-				"speed_mps": spd,
+				"time_iso":        timeISO,
+				"elevation":       ele,
+				"hr":              hr,
+				"speed_mps":       spd,
+				"pace_min_per_km": pace,
 			},
 		}
 

--- a/backend/internal/series/pace.go
+++ b/backend/internal/series/pace.go
@@ -1,0 +1,26 @@
+package series
+
+import "math"
+
+// SpeedToPaceMinPerKm converts an array of speeds (m/s) into pace expressed as
+// decimal minutes per kilometre (e.g. 5.12 = 5'12"). Nil or non-positive
+// speeds produce nil entries.
+func SpeedToPaceMinPerKm(speeds []*float64) []*float64 {
+	res := make([]*float64, len(speeds))
+	for i, v := range speeds {
+		if v == nil || *v <= 0 {
+			res[i] = nil
+			continue
+		}
+
+		secPerKm := 1000 / *v
+		minutes := math.Floor(secPerKm / 60)
+		seconds := math.Round(math.Mod(secPerKm, 60))
+		pace := minutes + seconds/100
+
+		// copy to avoid aliasing input values
+		p := pace
+		res[i] = &p
+	}
+	return res
+}

--- a/backend/internal/series/pace_test.go
+++ b/backend/internal/series/pace_test.go
@@ -1,0 +1,36 @@
+package series
+
+import "testing"
+
+func TestSpeedToPaceMinPerKm(t *testing.T) {
+	tests := []struct {
+		name   string
+		speed  *float64
+		expect *float64
+	}{
+		{name: "nil input", speed: nil, expect: nil},
+		{name: "zero speed", speed: ptr(0), expect: nil},
+		{name: "negative speed", speed: ptr(-1), expect: nil},
+		{name: "4 mps", speed: ptr(4), expect: ptr(4.10)},
+		{name: "3.33 mps", speed: ptr(3.33), expect: ptr(5.00)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SpeedToPaceMinPerKm([]*float64{tt.speed})[0]
+			if (got == nil) != (tt.expect == nil) {
+				t.Fatalf("nil mismatch: got %v expect %v", got, tt.expect)
+			}
+			if got == nil {
+				return
+			}
+			if diff := *got - *tt.expect; diff < -0.005 || diff > 0.005 {
+				t.Fatalf("pace mismatch: got %v expect %v", *got, *tt.expect)
+			}
+		})
+	}
+}
+
+func ptr(f float64) *float64 {
+	return &f
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -27,24 +27,15 @@ onMounted(async () => {
 function toKmh(arr) {
   return arr.map((v) => (v == null ? null : v * 3.6))
 }
-function toPaceMinPerKm(arr) {
-  // m/s -> s/m -> s/km -> min/km
-  return arr.map((v) => {
-    if (v == null || v <= 0) return null
-    const secPerKm = 1000 / v
-    const m = Math.floor(secPerKm / 60)
-    const s = Math.round(secPerKm % 60)
-    return Number(`${m}.${String(s).padStart(2, '0')}`) // e.g., 5.12 meaning 5'12"
-  })
-}
 const speedSeries = computed(() => {
   if (!detail.value) return []
   const src = detail.value.series.speed_mps
+  const pace = detail.value.series.pace_min_per_km
   switch (store.unit) {
     case 'kmh':
       return toKmh(src)
     case 'pace':
-      return toPaceMinPerKm(src) // “min.km” formatting explained below
+      return pace
     default:
       return src
   }


### PR DESCRIPTION
## Summary
- add backend helper to convert speed readings to pace and include it in the activity track response
- move pace unit selection in the frontend to use the backend-provided series
- cover the pace conversion logic with unit tests

## Testing
- go test ./...
- go test ./... -run TestSpeedToPaceMinPerKm -count=1 -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953af4a151483238c9348054f9b0c27)