### PR TITLE
Move pace calculation to backend

### DIFF
--- a/backend/internal/series/pace.go
+++ b/backend/internal/series/pace.go
@@ -1,9 +1,7 @@
 package series
 
-import "math"
-
 // SpeedToPaceMinPerKm converts an array of speeds (m/s) into pace expressed as
-// decimal minutes per kilometre (e.g. 5.12 = 5'12"). Nil or non-positive
+// decimal minutes per kilometre (e.g. 5.55 = 5'33"). Nil or non-positive
 // speeds produce nil entries.
 func SpeedToPaceMinPerKm(speeds []*float64) []*float64 {
 	res := make([]*float64, len(speeds))
@@ -14,9 +12,7 @@ func SpeedToPaceMinPerKm(speeds []*float64) []*float64 {
 		}
 
 		secPerKm := 1000 / *v
-		minutes := math.Floor(secPerKm / 60)
-		seconds := math.Round(math.Mod(secPerKm, 60))
-		pace := minutes + seconds/100
+		pace := secPerKm / 60
 
 		// copy to avoid aliasing input values
 		p := pace

--- a/backend/internal/series/pace_test.go
+++ b/backend/internal/series/pace_test.go
@@ -11,8 +11,8 @@ func TestSpeedToPaceMinPerKm(t *testing.T) {
 		{name: "nil input", speed: nil, expect: nil},
 		{name: "zero speed", speed: ptr(0), expect: nil},
 		{name: "negative speed", speed: ptr(-1), expect: nil},
-		{name: "4 mps", speed: ptr(4), expect: ptr(4.10)},
-		{name: "3.33 mps", speed: ptr(3.33), expect: ptr(5.00)},
+		{name: "4 mps", speed: ptr(4), expect: ptr(4.17)},
+		{name: "3.33 mps", speed: ptr(3.33), expect: ptr(5.01)},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- compute pace values on the backend in true decimal minutes per kilometre
- remove the frontend fallback pace calculation to rely on server-provided series
- update pace conversion tests to match the corrected calculation

## Testing
- go test ./internal/series -run TestSpeedToPaceMinPerKm
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b61eecdc8323af0ab2c6a79d22fe)