### PR TITLE
Add preview deploy workflow and ingress routing

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,210 @@
+name: PR Preview Environments
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BACKEND: ghcr.io/tazyvova/trackandfeel-backend
+  IMAGE_FRONTEND: ghcr.io/tazyvova/trackandfeel-frontend
+  PREVIEW_INGRESS_NETWORK: trackandfeel-preview
+  PREVIEW_TTL_DAYS: 7
+
+jobs:
+  build-and-push:
+    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push backend preview image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          build-args: COMMIT=${{ github.event.pull_request.head.sha }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_BACKEND }}:pr-${{ github.event.pull_request.number }}
+
+      - name: Build & push frontend preview image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          build-args: COMMIT=${{ github.event.pull_request.head.sha }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_FRONTEND }}:pr-${{ github.event.pull_request.number }}
+
+  deploy-preview:
+    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docker-compose.preview.yml
+            docker-compose.prod.yml
+            Caddyfile
+          sparse-checkout-cone-mode: false
+
+      - name: Upload infra files to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          passphrase: ${{ secrets.VDS_SSH_PASSPHRASE }}
+          source: "docker-compose.preview.yml,docker-compose.prod.yml,Caddyfile"
+          target: ${{ secrets.VDS_WORKDIR }}
+          overwrite: true
+
+      - name: Deploy preview stack
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          passphrase: ${{ secrets.VDS_SSH_PASSPHRASE }}
+          script_stop: true
+          command_timeout: 20m
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.VDS_WORKDIR }}"
+
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            PROJECT_NAME="trackandfeel-pr-${PR_NUMBER}"
+            PREVIEW_DOMAIN=${{ secrets.PREVIEW_DOMAIN }}
+            IMAGE_TAG="pr-${PR_NUMBER}"
+            NETWORK_NAME=${PREVIEW_INGRESS_NETWORK:-trackandfeel-preview}
+
+            echo "Creating ingress network ${NETWORK_NAME} if missing"
+            docker network create "${NETWORK_NAME}" || true
+
+            cat > .env.pr-${PR_NUMBER} <<EOF_ENV
+DB_NAME=${{ secrets.DB_NAME }}
+DB_USER=${{ secrets.DB_USER }}
+DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+IMAGE_TAG=${IMAGE_TAG}
+PR_NUMBER=${PR_NUMBER}
+COMMIT=${{ github.event.pull_request.head.sha }}
+PREVIEW_INGRESS_NETWORK=${NETWORK_NAME}
+EOF_ENV
+
+            echo "Logging into GHCR"
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+            echo "Starting preview stack ${PROJECT_NAME}"
+            docker compose -p "${PROJECT_NAME}" -f docker-compose.preview.yml --env-file .env.pr-${PR_NUMBER} pull
+            docker compose -p "${PROJECT_NAME}" -f docker-compose.preview.yml --env-file .env.pr-${PR_NUMBER} up -d --no-build --force-recreate
+
+            echo "Refreshing main Caddy with wildcard preview config"
+            PREVIEW_DOMAIN="${PREVIEW_DOMAIN}" PREVIEW_INGRESS_NETWORK="${NETWORK_NAME}" docker compose -f docker-compose.prod.yml up -d caddy
+            docker exec trackandfeel-caddy caddy reload --config /etc/caddy/Caddyfile || true
+
+      - name: Post preview URL
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_DOMAIN: ${{ secrets.PREVIEW_DOMAIN }}
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const url = `https://pr-${pr}.${process.env.PREVIEW_DOMAIN}`;
+            const body = `🚀 Preview available at **${url}**\n\nProject: trackandfeel-pr-${pr}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });
+
+  teardown-preview:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Remove preview stack and images
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          passphrase: ${{ secrets.VDS_SSH_PASSPHRASE }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.VDS_WORKDIR }}"
+
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            PROJECT_NAME="trackandfeel-pr-${PR_NUMBER}"
+
+            echo "Stopping preview stack ${PROJECT_NAME}"
+            docker compose -p "${PROJECT_NAME}" -f docker-compose.preview.yml down -v --remove-orphans || true
+
+            echo "Removing preview images"
+            docker image rm ${IMAGE_BACKEND:-ghcr.io/tazyvova/trackandfeel-backend}:pr-${PR_NUMBER} || true
+            docker image rm ${IMAGE_FRONTEND:-ghcr.io/tazyvova/trackandfeel-frontend}:pr-${PR_NUMBER} || true
+
+  gc-previews:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Garbage collect stale preview stacks
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          passphrase: ${{ secrets.VDS_SSH_PASSPHRASE }}
+          script_stop: true
+          command_timeout: 20m
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.VDS_WORKDIR }}"
+
+            TTL_DAYS=${PREVIEW_TTL_DAYS:-7}
+            CUTOFF=$(date -d "${TTL_DAYS} days ago" +%s)
+            echo "Collecting stacks older than ${TTL_DAYS} days (cutoff ${CUTOFF})"
+
+            for container in $(docker ps -a --format '{{.Names}}' | grep 'trackandfeel-pr-[0-9]\+-backend' || true); do
+              CREATED=$(docker inspect -f '{{.Created}}' "$container")
+              CREATED_TS=$(date -d "$CREATED" +%s)
+              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                PR_ID=$(echo "$container" | sed -E 's/.*pr-([0-9]+)-backend/\1/')
+                PROJECT_NAME="trackandfeel-pr-${PR_ID}"
+                echo "Pruning ${PROJECT_NAME} (created ${CREATED})"
+                docker compose -p "${PROJECT_NAME}" -f docker-compose.preview.yml down -v --remove-orphans || true
+                docker image rm ${IMAGE_BACKEND:-ghcr.io/tazyvova/trackandfeel-backend}:pr-${PR_ID} || true
+                docker image rm ${IMAGE_FRONTEND:-ghcr.io/tazyvova/trackandfeel-frontend}:pr-${PR_ID} || true
+              fi
+            done

--- a/Caddyfile
+++ b/Caddyfile
@@ -2,20 +2,23 @@
   email {$ACME_EMAIL}
 }
 
+(api-routes) {
+  handle /api/* {
+    reverse_proxy {args.0}
+  }
+
+  handle /healthz {
+    reverse_proxy {args.0}
+  }
+
+  handle /version {
+    reverse_proxy {args.0}
+  }
+}
+
 {$DOMAIN} {
   route {
-    # keep the /api prefix when proxying
-    handle /api/* {
-      reverse_proxy backend:8080
-    }
-
-    handle /healthz {
-      reverse_proxy backend:8080
-    }
-
-    handle /version {
-      reverse_proxy backend:8080
-    }
+    import api-routes backend:8080
 
     handle /frontend-version {
       root * /usr/share/nginx/html
@@ -23,7 +26,6 @@
       file_server
     }
 
-    # SPA fallback
     handle {
       root * /usr/share/nginx/html
       try_files {path} /index.html
@@ -41,20 +43,34 @@
   encode zstd gzip
 }
 
+*.{$PREVIEW_DOMAIN} {
+  @preview host_regexp prHost ^pr-(?P<prnum>[0-9]+)\.{$PREVIEW_DOMAIN}$
+
+  route @preview {
+    import api-routes pr-{http.regexp.prnum}-backend:8080
+
+    handle /frontend-version {
+      reverse_proxy pr-{http.regexp.prnum}-frontend:80
+    }
+
+    handle {
+      reverse_proxy pr-{http.regexp.prnum}-frontend:80
+    }
+  }
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    X-Content-Type-Options "nosniff"
+    X-Frame-Options "DENY"
+    Referrer-Policy "strict-origin-when-cross-origin"
+  }
+
+  encode zstd gzip
+}
+
 localhost {
   route {
-    # keep the /api prefix when proxying
-    handle /api/* {
-      reverse_proxy backend:8080
-    }
-
-    handle /healthz {
-      reverse_proxy backend:8080
-    }
-
-    handle /version {
-      reverse_proxy backend:8080
-    }
+    import api-routes backend:8080
 
     handle /frontend-version {
       root * /usr/share/nginx/html
@@ -62,7 +78,6 @@ localhost {
       file_server
     }
 
-    # SPA fallback
     handle {
       root * /usr/share/nginx/html
       try_files {path} /index.html

--- a/README.md
+++ b/README.md
@@ -20,3 +20,30 @@ Run backend tests in a disposable container so nothing lingers after the run:
 ```
 docker compose -f docker-compose.yml -f docker-compose.test.yml run --rm backend-test
 ```
+
+## Preview environments
+
+Pull requests automatically get an ephemeral preview stack using the `PR Preview Environments` workflow. Key behaviours:
+
+- Backend and frontend images are built from the PR head SHA, tagged as `pr-<number>`, and pushed to GHCR.
+- The workflow connects to the VDS over SSH, launches a per-PR Compose project (`trackandfeel-pr-<number>`) using `docker-compose.preview.yml`, and reuses the shared `trackandfeel-preview` ingress network so Caddy can discover the services.
+- Caddy uses the wildcard block in `Caddyfile` to proxy `pr-<number>.<preview-domain>` to the matching preview backend/frontend while keeping the `/api`, `/healthz`, `/version`, and SPA behaviour consistent with production.
+- A PR comment is posted with the preview URL; the stack and images are removed when the PR closes, and the scheduled GC job prunes stacks older than the configured TTL.
+
+### Required secrets and environment
+
+Set these repository secrets to enable the workflow:
+
+- `VDS_HOST`, `VDS_USER`, `VDS_SSH_KEY`, `VDS_SSH_PASSPHRASE`, `VDS_WORKDIR` – reused from the existing deploy workflows.
+- `DB_NAME`, `DB_USER`, `DB_PASSWORD` – credentials for the preview Postgres containers.
+- `PREVIEW_DOMAIN` – the wildcard domain (e.g. `preview.example.com`) pointing DNS `*.PREVIEW_DOMAIN` to the product server.
+
+Add these values to the server’s `.env` (or export before running compose):
+
+- `PREVIEW_DOMAIN` – shared by Caddy to match wildcard hosts.
+- `PREVIEW_INGRESS_NETWORK` (default `trackandfeel-preview`) – the external Docker network that connects the central Caddy container to each preview stack.
+
+Local validation hints:
+
+- `docker compose -f docker-compose.preview.yml --env-file .env.local config` verifies env interpolation for a given PR number.
+- Run `./.github/workflows/pr-preview.yml` with `workflow_dispatch` to smoke-test registry pushes and remote deployment without opening a real PR.

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,0 +1,59 @@
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  backend:
+    image: ${IMAGE_BACKEND:-ghcr.io/tazyvova/trackandfeel-backend}:${IMAGE_TAG:-latest}
+    environment:
+      PORT: "8080"
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+    depends_on:
+      db:
+        condition: service_healthy
+    expose:
+      - "8080"
+    networks:
+      - default
+      preview_ingress:
+        aliases:
+          - pr-${PR_NUMBER}-backend
+    restart: unless-stopped
+
+  frontend:
+    image: ${IMAGE_FRONTEND:-ghcr.io/tazyvova/trackandfeel-frontend}:${IMAGE_TAG:-latest}
+    environment:
+      - COMMIT=$COMMIT
+    depends_on:
+      - backend
+    expose:
+      - "80"
+    networks:
+      - default
+      preview_ingress:
+        aliases:
+          - pr-${PR_NUMBER}-frontend
+    restart: unless-stopped
+
+volumes:
+  db_data:
+
+networks:
+  preview_ingress:
+    external: true
+    name: ${PREVIEW_INGRESS_NETWORK:-trackandfeel-preview}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,7 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       ACME_EMAIL: ${ACME_EMAIL}
+      PREVIEW_DOMAIN: ${PREVIEW_DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       # Static files served directly by Caddy (optional optimization):
@@ -66,6 +67,9 @@ services:
       # Certificates (persist)
       - caddy_data:/data
       - caddy_config:/config
+    networks:
+      - default
+      - preview_ingress
     restart: unless-stopped
 
 volumes:
@@ -73,3 +77,8 @@ volumes:
   frontend_dist:
   caddy_data:
   caddy_config:
+
+networks:
+  preview_ingress:
+    external: true
+    name: ${PREVIEW_INGRESS_NETWORK:-trackandfeel-preview}


### PR DESCRIPTION
## Summary
- add a PR preview workflow that builds/pushes pr-tagged images, deploys per-PR compose stacks, and comments the preview URL
- extend Caddy and compose config to support wildcard preview hosts via a shared ingress network
- document the preview workflow, required secrets, and local validation steps

## Testing
- Not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540e8080588323933120e4fe95f3ff)