### PR TITLE
Fix preview docker-compose network configuration

### DIFF
--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -29,7 +29,7 @@ services:
     expose:
       - "8080"
     networks:
-      default:
+      default: {}
       preview_ingress:
         aliases:
           - pr-${PR_NUMBER}-backend
@@ -44,7 +44,7 @@ services:
     expose:
       - "80"
     networks:
-      default:
+      default: {}
       preview_ingress:
         aliases:
           - pr-${PR_NUMBER}-frontend


### PR DESCRIPTION
## Summary
- fix network configuration sections for backend and frontend services in preview compose file
- keep alias definitions under network maps for preview ingress

## Testing
- docker compose -f docker-compose.preview.yml config

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542460844c8323913cd6e728a11701)