### PR TITLE
fix: add default for PREVIEW_DOMAIN in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,7 +59,7 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       ACME_EMAIL: ${ACME_EMAIL}
-      PREVIEW_DOMAIN: ${PREVIEW_DOMAIN}
+      PREVIEW_DOMAIN: ${PREVIEW_DOMAIN:-preview.local}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       # Static files served directly by Caddy (optional optimization):


### PR DESCRIPTION
Fixes production Caddy crash caused by empty PREVIEW_DOMAIN env var.