### PR TITLE
fix: backend version mismatch in deployment validation

### DIFF
--- a/.github/workflows/deploy-build.yml
+++ b/.github/workflows/deploy-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./backend
-          build-args: COMMIT=${{ github.sha }}
+          build-args: COMMIT=${{ github.event.workflow_run.head_sha }}
           push: true
           tags: |
             ${{ env.IMAGE_BACKEND }}:latest


### PR DESCRIPTION
Fixes the backend version mismatch that was causing deployment validation to fail. Uses github.event.workflow_run.head_sha instead of github.sha for the COMMIT build arg.