### PR TITLE
fix: bind dev ports to localhost only

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
 
 # act (local CI runner)
 RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
-    mv bin/act /usr/local/bin/ && rmdir bin
+    mv bin/act /usr/local/bin/ && rm -rf bin
 
 # gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs
 
 # act (local CI runner)
-RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
-    mv bin/act /usr/local/bin/ && rm -rf bin
+RUN cd /tmp && curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
+    mv /tmp/bin/act /usr/local/bin/ && rm -rf /tmp/bin
 
 # gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Go 1.23
+RUN wget -qO- https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH="/usr/local/go/bin:/home/vscode/go/bin:${PATH}"
+
+# Node 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs
+
+# act (local CI runner)
+RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
+    mv bin/act /usr/local/bin/ && rmdir bin
+
+# gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y gh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "TrackAndFeel Dev",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.extend.yml"
+  ],
+  "service": "devcontainer",
+  "runServices": ["db", "backend", "frontend", "devcontainer"],
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [5173, 8080, 5432],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.Go",
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker",
+        "github.vscode-github-actions"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "[go]": {
+          "editor.defaultFormatter": "golang.go"
+        },
+        "[vue]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "files.eol": "\n",
+        "go.toolsManagement.autoUpdate": true
+      }
+    }
+  },
+  "postCreateCommand": "cd /workspace/frontend && npm ci"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,5 +34,5 @@
       }
     }
   },
-  "postCreateCommand": "cd /workspace/frontend && npm ci"
+  "postCreateCommand": "sudo chown -R vscode:vscode /workspace/frontend/node_modules 2>/dev/null; cd /workspace/frontend && npm ci"
 }

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -1,10 +1,10 @@
 services:
   devcontainer:
     build:
-      context: .
+      context: .devcontainer
       dockerfile: Dockerfile
     volumes:
-      - ..:/workspace:cached
+      - .:/workspace:cached
       - /var/run/docker.sock:/var/run/docker.sock
     working_dir: /workspace
     command: sleep infinity

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -1,0 +1,19 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /workspace
+    command: sleep infinity
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: training

--- a/LOCAL_CI.md
+++ b/LOCAL_CI.md
@@ -1,0 +1,50 @@
+# Local CI/CD with `act`
+
+This project is configured with a dedicated Dev Container that has [`act`](https://github.com/nektos/act) pre-installed.
+
+## How to use it
+
+1. Open in Dev Container:
+   - Press `F1` (or `Ctrl+Shift+P`).
+   - Run `Dev Containers: Reopen in Container`.
+   - Wait for the build to finish. You are inside when VS Code shows `Dev Container: TrackAndFeel Dev`.
+2. Open a terminal (`Ctrl+Shift+\`` or terminal menu) inside the dev container.
+3. Confirm services are running:
+
+```bash
+docker compose ps
+```
+
+The compose stack starts `db`, `backend`, and `frontend` automatically for this setup.
+
+## Running workflows
+
+To see all available workflows:
+
+```bash
+act --list
+```
+
+### Simulate a pull request
+
+```bash
+act pull_request
+```
+
+### Simulate a push to `master`
+
+```bash
+act push -b master
+```
+
+### Run a specific job
+
+```bash
+act -j backend
+```
+
+## Troubleshooting
+
+- Large runner image: on first run, `act` asks for image size. `Medium` is usually a good balance.
+- Docker socket: `act` requires Docker socket access; it is mounted in `.devcontainer/docker-compose.extend.yml`.
+- Secrets: pass secrets via `.secrets` file or command line, for example `--secret SECRET_NAME=value`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: training
     ports:
-      - "5432:5432"            # host:container (optional if you access DB from host tools)
+      - "127.0.0.1:5432:5432"  # localhost only — never expose DB to the internet
     volumes:
       - dbdata:/var/lib/postgresql/data
     healthcheck:
@@ -31,7 +31,7 @@ services:
       DB_PASSWORD: postgres
       DB_NAME: training
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     depends_on:
       db:
         condition: service_healthy
@@ -44,7 +44,7 @@ services:
       - ./frontend:/app        # bind-mount so changes reflect instantly
     command: sh -c "npm ci || npm i && npm run dev -- --host 0.0.0.0"
     ports:
-      - "5173:5173"            # Vite dev server
+      - "127.0.0.1:5173:5173"  # Vite dev server — VS Code tunnels this automatically
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- PostgreSQL (5432), backend (8080), and frontend (5173) were bound to `0.0.0.0`, exposing them publicly
- Restricted all three to `127.0.0.1` — VS Code Remote SSH tunnels them automatically so dev workflow is unchanged
- This prevents the attack vector that allowed a ransomware bot to wipe the dev database

## Test plan
- [ ] `ss -tlnp` shows ports bound to `127.0.0.1` not `0.0.0.0`
- [ ] VS Code port forwarding still works for local access
- [ ] `docker compose up` starts all services successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)